### PR TITLE
Add GitLab CI configuration for build, test, and release stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,45 @@
+stages:
+- build
+- test
+- release
+
+variables:
+  GO_VERSION: "1.23"
+
+before_script:
+- apt-get update -qq && apt-get install -qqy zip unzip
+
+build:
+  stage: build
+  image: golang:${GO_VERSION}
+  script:
+  - go build -v -o PowerShellProfileLauncher.exe
+  - zip PowerShellProfileLauncher.zip PowerShellProfileLauncher.exe profiles.csv.tmpl config.json.tmpl
+  artifacts:
+    paths:
+    - PowerShellProfileLauncher.zip
+
+test:
+  stage: test
+  image: golang:${GO_VERSION}
+  script:
+  - go test -v ./...
+
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+  - echo "Creating release"
+  needs:
+  - build
+  - test
+  rules:
+  - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+  release:
+    name: "Release $CI_COMMIT_TAG"
+    tag_name: "$CI_COMMIT_TAG"
+    description: "Release notes for $CI_COMMIT_TAG"
+    assets:
+      links:
+      - name: "PowerShellProfileLauncher.zip"
+        url: "$CI_PROJECT_URL/-/jobs/$CI_JOB_ID/artifacts/download"


### PR DESCRIPTION
Introduce a GitLab CI configuration to automate the build, test, and release processes for the project. This setup includes stages for building the application, running tests, and creating releases based on version tags.